### PR TITLE
Fix branch switching when new directories added.

### DIFF
--- a/lvn/switch.py
+++ b/lvn/switch.py
@@ -29,8 +29,11 @@ def Switch(args):
   try:
     lvn.SaveCurrentBranch()
     lvn.Revert()
+    archive = lvn.SaveNonTracked()
+    lvn.Clean()
     lvn.current_branch = args.branch
     lvn.RestoreBranch()
+    lvn.RestoreNonTracked(archive)
   finally:
     lvn.Save()
 


### PR DESCRIPTION
There is a problem with `svn patch` when directory already exists that will be
added by the patch. The solution is to store every non-tracked file and
directory into an archive, remove them from working tree and restore back
afterwards.
